### PR TITLE
Add missing Neko variants to drop-down menu

### DIFF
--- a/internal/config/room.go
+++ b/internal/config/room.go
@@ -36,7 +36,7 @@ func (Room) Init(cmd *cobra.Command) error {
 		return err
 	}
 
-	cmd.PersistentFlags().StringSlice("neko_images", []string{"m1k1o/neko:latest", "m1k1o/neko:chromium"}, "neko images to be used")
+	cmd.PersistentFlags().StringSlice("neko_images", []string{"m1k1o/neko:latest", "m1k1o/neko:chromium", "m1k1o/neko:ungoogled-chromium", "m1k1o/neko:vlc", "m1k1o/neko:vncviewer", "m1k1o/neko:xfce"}, "neko images to be used")
 	if err := viper.BindPFlag("neko_images", cmd.PersistentFlags().Lookup("neko_images")); err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request adds the other tags of the Neko image to the drop-down menu.