### PR TITLE
Add wait handler for rooms

### DIFF
--- a/internal/config/room.go
+++ b/internal/config/room.go
@@ -31,6 +31,7 @@ type Room struct {
 	NekoPrivilegedImages []string
 	PathPrefix           string
 	Labels               []string
+	WaitEnabled          bool
 
 	StorageEnabled  bool
 	StorageInternal string
@@ -90,6 +91,11 @@ func (Room) Init(cmd *cobra.Command) error {
 
 	cmd.PersistentFlags().StringSlice("labels", []string{}, "additional labels appended to every room")
 	if err := viper.BindPFlag("labels", cmd.PersistentFlags().Lookup("labels")); err != nil {
+		return err
+	}
+
+	cmd.PersistentFlags().Bool("wait_enabled", true, "enable active waiting for the room")
+	if err := viper.BindPFlag("wait_enabled", cmd.PersistentFlags().Lookup("wait_enabled")); err != nil {
 		return err
 	}
 
@@ -199,6 +205,7 @@ func (s *Room) Set() {
 	s.NekoPrivilegedImages = viper.GetStringSlice("neko_privileged_images")
 	s.PathPrefix = path.Join("/", path.Clean(viper.GetString("path_prefix")))
 	s.Labels = viper.GetStringSlice("labels")
+	s.WaitEnabled = viper.GetBool("wait_enabled")
 
 	s.StorageEnabled = viper.GetBool("storage.enabled")
 	s.StorageInternal = viper.GetString("storage.internal")

--- a/internal/proxy/lobby.go
+++ b/internal/proxy/lobby.go
@@ -6,6 +6,40 @@ import (
 	"github.com/m1k1o/neko-rooms/internal/utils"
 )
 
+func roomWait(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte(`<script>
+	(async function() {
+		document.querySelector(".swal2-loader").style.display = 'block'
+		document.querySelector(".swal2-loader").style.visibility = 'hidden'
+
+		let lastAttempt = (new Date()).getTime()
+		while(true) {
+			try {
+				lastAttempt = (new Date()).getTime()
+				document.querySelector(".swal2-loader").style.visibility = 'visible'
+
+				await fetch("?wait")
+				location.href = location.href
+			} catch {
+				let now = (new Date()).getTime()
+				let diff = now - lastAttempt
+
+				// if the gap between last attempt and now
+				// is gt 20s, do reconnect immediatly
+				if ((now - lastAttempt) > 20*1000) {
+					continue
+				}
+
+				// wait for 10 sec
+				await new Promise(res => setTimeout(res, 2500))
+				document.querySelector(".swal2-loader").style.visibility = 'hidden'
+				await new Promise(res => setTimeout(res, 7500))
+			}
+		}
+	}())
+	</script>`))
+}
+
 func RoomNotFound(w http.ResponseWriter, r *http.Request) {
 	utils.Swal2Response(w, `
 		<div class="swal2-header">
@@ -16,8 +50,14 @@ func RoomNotFound(w http.ResponseWriter, r *http.Request) {
 		</div>
 		<div class="swal2-content">
 			<div>The room you are trying to join does not exist.</div>
+			<div>You can wait on this page until it will be created.</div>
+		</div>
+		<div class="swal2-actions">
+			<div class="swal2-loader" style="display:none;"></div>
 		</div>
 	`)
+
+	roomWait(w, r)
 }
 
 func RoomNotRunning(w http.ResponseWriter, r *http.Request) {
@@ -30,8 +70,14 @@ func RoomNotRunning(w http.ResponseWriter, r *http.Request) {
 		</div>
 		<div class="swal2-content">
 			<div>The room you are trying to join is not running.</div>
+			<div>You can wait on this page until it will be started.</div>
+		</div>
+		<div class="swal2-actions">
+			<div class="swal2-loader" style="display:none;"></div>
 		</div>
 	`)
+
+	roomWait(w, r)
 }
 
 func RoomNotReady(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/lobby.go
+++ b/internal/proxy/lobby.go
@@ -40,7 +40,7 @@ func roomWait(w http.ResponseWriter, r *http.Request) {
 	</script>`))
 }
 
-func RoomNotFound(w http.ResponseWriter, r *http.Request) {
+func RoomNotFound(w http.ResponseWriter, r *http.Request, waitEnabled bool) {
 	utils.Swal2Response(w, `
 		<div class="swal2-header">
 			<div class="swal2-icon swal2-error">
@@ -57,10 +57,12 @@ func RoomNotFound(w http.ResponseWriter, r *http.Request) {
 		</div>
 	`)
 
-	roomWait(w, r)
+	if waitEnabled {
+		roomWait(w, r)
+	}
 }
 
-func RoomNotRunning(w http.ResponseWriter, r *http.Request) {
+func RoomNotRunning(w http.ResponseWriter, r *http.Request, waitEnabled bool) {
 	utils.Swal2Response(w, `
 		<div class="swal2-header">
 			<div class="swal2-icon swal2-warning">
@@ -77,7 +79,9 @@ func RoomNotRunning(w http.ResponseWriter, r *http.Request) {
 		</div>
 	`)
 
-	roomWait(w, r)
+	if waitEnabled {
+		roomWait(w, r)
+	}
 }
 
 func RoomNotReady(w http.ResponseWriter, r *http.Request) {

--- a/neko.go
+++ b/neko.go
@@ -145,6 +145,7 @@ func (main *MainCtx) Start() {
 	main.proxyManager = proxy.New(
 		client,
 		main.Configs.Room.InstanceName,
+		main.Configs.Room.WaitEnabled,
 	)
 	main.proxyManager.Start()
 


### PR DESCRIPTION
When a room does not exists or is not running, static page is show. I want that page to refresh once room is available. That can be acheivied by a blocking page request, that does not load until the room is ready. Same principle as [SSE](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events) but only event that we send is when the page is ready.