### PR TITLE
Allow installing extensions

### DIFF
--- a/OpenApi.yml
+++ b/OpenApi.yml
@@ -501,6 +501,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BrowserPolicyExtension'
+        install_extensions:
+          type: boolean
+          example: false
         developer_tools:
           type: boolean
           example: true

--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -73,6 +73,12 @@ export interface BrowserPolicyContent {
      * @type {boolean}
      * @memberof BrowserPolicyContent
      */
+    'install_extensions'?: boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof BrowserPolicyContent
+     */
     'developer_tools'?: boolean;
     /**
      * 

--- a/client/src/components/RoomInfo.vue
+++ b/client/src/components/RoomInfo.vue
@@ -189,6 +189,7 @@
                 <template v-slot:default>
                   <tbody>
                     <tr><th> Extensions </th><td>{{ BrowserExtensions(settings.browser_policy.content.extensions).join(', ') }}</td></tr>
+                    <tr><th> Install extensions </th><td>{{ settings.browser_policy.content.install_extensions }}</td></tr>
                     <tr><th> Developer tools </th><td>{{ settings.browser_policy.content.developer_tools }}</td></tr>
                     <tr><th> Persistent data </th><td>{{ settings.browser_policy.content.persistent_data }}</td></tr>
                   </tbody>

--- a/client/src/components/RoomsCreate.vue
+++ b/client/src/components/RoomsCreate.vue
@@ -406,12 +406,13 @@
           <v-row align="center">
             <v-col>
               <v-checkbox
-                v-model="browserPolicyContent.developer_tools"
-                label="Enable developer tools"
+                v-model="browserPolicyContent.install_extensions"
+                label="Allow installing extensions"
                 hide-details
                 class="shrink ml-2 mt-0"
                 :disabled="!browserPolicyEnabled"
               ></v-checkbox>
+              <div style="margin-left: 41px;"><i>User can install any extension from the Chrome Web Store.</i></div>
             </v-col>
             <v-col>
               <v-checkbox
@@ -421,8 +422,22 @@
                 class="shrink ml-2 mt-0"
                 :disabled="!browserPolicyEnabled"
               ></v-checkbox>
+              <div style="margin-left: 41px;"><i>All cookies, local storage, etc. will be persistent between restarts.</i></div>
             </v-col>
           </v-row>
+
+          <v-row align="center">
+            <v-col>
+              <v-checkbox
+                v-model="browserPolicyContent.developer_tools"
+                label="Enable developer tools"
+                hide-details
+                class="shrink ml-2 mt-0"
+                :disabled="!browserPolicyEnabled"
+              ></v-checkbox>
+            </v-col>
+          </v-row>
+
         </template>
         <v-alert
           border="left"

--- a/client/src/store/state.ts
+++ b/client/src/store/state.ts
@@ -309,6 +309,8 @@ export const state = {
   defaultBrowserPolicyContent: {
     extensions: [],
     // eslint-disable-next-line
+    install_extensions: false,
+    // eslint-disable-next-line
     developer_tools: false,
     // eslint-disable-next-line
     persistent_data: false,

--- a/internal/policies/chromium/generator.go
+++ b/internal/policies/chromium/generator.go
@@ -46,7 +46,14 @@ func Generate(policies types.BrowserPolicyContent) (string, error) {
 
 	policiesTmpl["ExtensionInstallForcelist"] = ExtensionInstallForcelist
 	policiesTmpl["ExtensionInstallAllowlist"] = ExtensionInstallAllowlist
-	policiesTmpl["ExtensionInstallBlocklist"] = []interface{}{"*"}
+
+	if policies.InstallExtensions {
+		// Allow installation of extensions
+		policiesTmpl["ExtensionInstallBlocklist"] = []interface{}{}
+	} else {
+		// Disallow installation of extensions
+		policiesTmpl["ExtensionInstallBlocklist"] = []interface{}{"*"}
+	}
 
 	//
 	// Developer Tools

--- a/internal/policies/chromium/parser.go
+++ b/internal/policies/chromium/parser.go
@@ -36,6 +36,14 @@ func Parse(policiesJson string) (*types.BrowserPolicyContent, error) {
 	}
 
 	//
+	// Install Extensions
+	//
+
+	if val, ok := policiesTmpl["ExtensionInstallBlocklist"]; ok {
+		policies.InstallExtensions = len(val.([]interface{})) == 0
+	}
+
+	//
 	// Developer Tools
 	//
 

--- a/internal/policies/firefox/generator.go
+++ b/internal/policies/firefox/generator.go
@@ -21,12 +21,21 @@ func Generate(policies types.BrowserPolicyContent) (string, error) {
 	}
 
 	//
+	// Install Extensions
+	//
+
+	installationMode := "blocked"
+	if policies.InstallExtensions {
+		installationMode = "allowed"
+	}
+
+	//
 	// Extensions
 	//
 
 	ExtensionSettings := map[string]interface{}{}
 	ExtensionSettings["*"] = map[string]interface{}{
-		"installation_mode": "blocked",
+		"installation_mode": installationMode,
 	}
 
 	for _, e := range policies.Extensions {

--- a/internal/policies/firefox/parser.go
+++ b/internal/policies/firefox/parser.go
@@ -32,6 +32,13 @@ func Parse(policiesJson string) (*types.BrowserPolicyContent, error) {
 		policies.Extensions = []types.BrowserPolicyExtension{}
 		for id, val := range extensions.(map[string]interface{}) {
 			if id == "*" {
+				//
+				// Install Extensions
+				//
+
+				if val, ok := val.(map[string]interface{})["installation_mode"]; ok {
+					policies.InstallExtensions = val.(string) == "allowed"
+				}
 				continue
 			}
 

--- a/internal/types/policies.go
+++ b/internal/types/policies.go
@@ -14,9 +14,10 @@ type BrowserPolicy struct {
 }
 
 type BrowserPolicyContent struct {
-	Extensions     []BrowserPolicyExtension `json:"extensions"`
-	DeveloperTools bool                     `json:"developer_tools"`
-	PersistentData bool                     `json:"persistent_data"`
+	Extensions        []BrowserPolicyExtension `json:"extensions"`
+	InstallExtensions bool                     `json:"install_extensions"`
+	DeveloperTools    bool                     `json:"developer_tools"`
+	PersistentData    bool                     `json:"persistent_data"`
 }
 
 type BrowserPolicyExtension struct {


### PR DESCRIPTION
Adding `Allow installing extensions` checkbos to allow further installations of extensions.

Currently the policy is not working properly.