### PR TITLE
Add room events and is ready status

### DIFF
--- a/OpenApi.yml
+++ b/OpenApi.yml
@@ -411,6 +411,9 @@ components:
         running:
           type: boolean
           example: true
+        is_ready:
+          type: boolean
+          example: true
         status:
           type: string
           example: Up 2 seconds

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -153,6 +153,12 @@ export default new Vuex.Store({
       const res = await defaultApi.pullStop()
       return res.data
     },
+
+    async EVENTS_SSE(): Promise<EventSource> {
+      return new EventSource(configuration.basePath + '/api/events?sse', {
+        withCredentials: true,
+      })
+    },
   },
   modules: {
   }

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -11,7 +11,9 @@ module.exports = defineConfig({
     proxy: process.env.API_PROXY ? {
       '^/api': {
         target: process.env.API_PROXY,
+        timeout: 0, // because of SSE
       },
     } : undefined,
+    compress: false, // because of SSE
   }
 })

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -61,5 +61,6 @@ func (manager *ApiManagerCtx) Mount(r chi.Router) {
 		r.Post("/recreate", manager.roomRecreate)
 	})
 
+	r.Get("/events", manager.events)
 	r.Get("/docker-compose.yaml", manager.dockerCompose)
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -61,6 +61,11 @@ func (manager *ApiManagerCtx) Mount(r chi.Router) {
 		r.Post("/recreate", manager.roomRecreate)
 	})
 
-	r.Get("/events", manager.events)
 	r.Get("/docker-compose.yaml", manager.dockerCompose)
+
+	//
+	// events
+	//
+
+	r.Get("/events", manager.events)
 }

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func (manager *ApiManagerCtx) events(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	sse := r.URL.Query().Has("sse")
+	if sse {
+		w.Header().Set("Content-Type", "text/event-stream")
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Connection does not support streaming", http.StatusBadRequest)
+		return
+	}
+
+	var ping <-chan time.Time
+	if !sse {
+		// dummy channel, never ping
+		ping = make(<-chan time.Time)
+	} else {
+		// ping every 1 minute
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+		ping = ticker.C
+	}
+
+	// listen for room events
+	events, errs := manager.rooms.Events(r.Context())
+	for {
+		select {
+		case <-ping:
+			fmt.Fprintf(w, ": ping\n\n")
+			flusher.Flush()
+		case _, ok := <-errs:
+			if !ok {
+				manager.logger.Debug().Msg("sse channel closed")
+			}
+			return
+		case e := <-events:
+			jsonData, err := json.Marshal(e)
+			if err != nil {
+				manager.logger.Err(err).Msg("failed to marshal event")
+				continue
+			}
+
+			if sse {
+				fmt.Fprintf(w, "event: rooms\n")
+				fmt.Fprintf(w, "data: %s\n\n", jsonData)
+			} else {
+				fmt.Fprintf(w, "rooms\t%s\n", jsonData)
+			}
+
+			flusher.Flush()
+		}
+	}
+}

--- a/internal/api/rooms.go
+++ b/internal/api/rooms.go
@@ -252,9 +252,15 @@ func (manager *ApiManagerCtx) roomGenericAction(action func(ctx context.Context,
 }
 
 func (manager *ApiManagerCtx) events(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
+
+	sse := r.URL.Query().Has("sse")
+	if sse {
+		w.Header().Set("Content-Type", "text/event-stream")
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+	}
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -277,7 +283,12 @@ func (manager *ApiManagerCtx) events(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			fmt.Fprintf(w, "data: %s\n\n", jsonData)
+			if sse {
+				fmt.Fprintf(w, "data: %s\n\n", jsonData)
+			} else {
+				fmt.Fprintf(w, "%s\n", jsonData)
+			}
+
 			flusher.Flush()
 		}
 	}

--- a/internal/config/room.go
+++ b/internal/config/room.go
@@ -32,6 +32,7 @@ type Room struct {
 	PathPrefix           string
 	Labels               []string
 	WaitEnabled          bool
+	StopTimeoutSec       int
 
 	StorageEnabled  bool
 	StorageInternal string
@@ -97,6 +98,11 @@ func (Room) Init(cmd *cobra.Command) error {
 
 	cmd.PersistentFlags().Bool("wait_enabled", true, "enable active waiting for the room")
 	if err := viper.BindPFlag("wait_enabled", cmd.PersistentFlags().Lookup("wait_enabled")); err != nil {
+		return err
+	}
+
+	cmd.PersistentFlags().Int("stop_timeout", 10, "timeout in seconds for stopping the room with SIGTERM, after that SIGKILL is used (0 to disable, -1 to wait forever)")
+	if err := viper.BindPFlag("stop_timeout", cmd.PersistentFlags().Lookup("stop_timeout")); err != nil {
 		return err
 	}
 
@@ -207,6 +213,7 @@ func (s *Room) Set() {
 	s.PathPrefix = path.Join("/", path.Clean(viper.GetString("path_prefix")))
 	s.Labels = viper.GetStringSlice("labels")
 	s.WaitEnabled = viper.GetBool("wait_enabled")
+	s.StopTimeoutSec = viper.GetInt("stop_timeout")
 
 	s.StorageEnabled = viper.GetBool("storage.enabled")
 	s.StorageInternal = viper.GetString("storage.internal")

--- a/internal/proxy/lobby.go
+++ b/internal/proxy/lobby.go
@@ -59,6 +59,8 @@ func RoomNotFound(w http.ResponseWriter, r *http.Request, waitEnabled bool) {
 
 	if waitEnabled {
 		roomWait(w, r)
+	} else {
+		w.Write([]byte(`<meta http-equiv="refresh" content="60">`))
 	}
 }
 
@@ -81,10 +83,12 @@ func RoomNotRunning(w http.ResponseWriter, r *http.Request, waitEnabled bool) {
 
 	if waitEnabled {
 		roomWait(w, r)
+	} else {
+		w.Write([]byte(`<meta http-equiv="refresh" content="10">`))
 	}
 }
 
-func RoomNotReady(w http.ResponseWriter, r *http.Request) {
+func RoomNotReady(w http.ResponseWriter, r *http.Request, waitEnabled bool) {
 	utils.Swal2Response(w, `
 		<meta http-equiv="refresh" content="2">
 
@@ -102,6 +106,12 @@ func RoomNotReady(w http.ResponseWriter, r *http.Request) {
 			<button type="button" onclick="location = location" class="swal2-confirm swal2-styled" style="margin-top: 1.25em">Reload</button>
 		</div>
 	`)
+
+	if waitEnabled {
+		roomWait(w, r)
+	} else {
+		w.Write([]byte(`<meta http-equiv="refresh" content="2">`))
+	}
 }
 
 func RoomReady(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/manager.go
+++ b/internal/proxy/manager.go
@@ -88,8 +88,8 @@ func (p *ProxyManagerCtx) Start() {
 					Str("host", host).
 					Msg("got room event")
 
-				// terminate waiting for any event
-				if p.waitEnabled {
+				// terminate waiting for room ready event
+				if p.waitEnabled && msg.Action == types.RoomEventReady {
 					p.waitMu.Lock()
 					ch, ok := p.waitChans[path]
 					if ok {

--- a/internal/room/containers.go
+++ b/internal/room/containers.go
@@ -34,6 +34,8 @@ func (manager *RoomManagerCtx) containerToEntry(container dockerTypes.Container)
 		Status:         container.Status,
 		Created:        time.Unix(container.Created, 0),
 		Labels:         labels.UserDefined,
+
+		ContainerLabels: container.Labels,
 	}
 
 	if labels.Mux {

--- a/internal/room/containers.go
+++ b/internal/room/containers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	dockerTypes "github.com/docker/docker/api/types"
@@ -19,14 +20,17 @@ func (manager *RoomManagerCtx) containerToEntry(container dockerTypes.Container)
 		return nil, err
 	}
 
+	roomId := container.ID[:12]
+
 	entry := &types.RoomEntry{
-		ID:             container.ID[:12],
+		ID:             roomId,
 		URL:            labels.URL,
 		Name:           labels.Name,
 		NekoImage:      labels.NekoImage,
 		IsOutdated:     labels.NekoImage != container.Image,
 		MaxConnections: labels.Epr.Max - labels.Epr.Min + 1,
 		Running:        container.State == "running",
+		IsReady:        manager.events.IsRoomReady(roomId) || strings.Contains(container.Status, "healthy"),
 		Status:         container.Status,
 		Created:        time.Unix(container.Created, 0),
 		Labels:         labels.UserDefined,

--- a/internal/room/events.go
+++ b/internal/room/events.go
@@ -84,8 +84,6 @@ func (e *events) Start() {
 				e.logger.Err(err).Msg("got docker event error")
 				return
 			case room := <-e.roomsReadyCh:
-				e.logger.Info().Str("id", room.id).Msg("room ready")
-
 				// ignore if room was already ready
 				if !e.setRoomReady(room.id) {
 					continue

--- a/internal/room/events.go
+++ b/internal/room/events.go
@@ -3,109 +3,254 @@ package room
 import (
 	"context"
 	"fmt"
+	"io"
+	"strings"
+	"sync"
 
+	"github.com/m1k1o/neko-rooms/internal/config"
 	"github.com/m1k1o/neko-rooms/internal/types"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	dockerTypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	dockerClient "github.com/docker/docker/client"
 )
 
-func (manager *RoomManagerCtx) EventsLoopStart() {
-	ctx, cancel := context.WithCancel(context.Background())
-	manager.eventsLoopCtx = ctx
-	manager.eventsLoopCancel = cancel
+type events struct {
+	wg sync.WaitGroup
 
-	msgs, errs := manager.client.Events(ctx, dockerTypes.EventsOptions{
+	logger zerolog.Logger
+	config *config.Room
+	client *dockerClient.Client
+
+	roomsReadyCh chan string
+	roomsReadyMu sync.Mutex
+	roomsReady   map[string]struct{}
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	listeners   []chan types.RoomEvent
+	listenersMu sync.Mutex
+}
+
+func newEvents(config *config.Room, client *dockerClient.Client) *events {
+	return &events{
+		logger: log.With().Str("module", "events").Logger(),
+		config: config,
+		client: client,
+
+		roomsReadyCh: make(chan string),
+		roomsReady:   make(map[string]struct{}),
+	}
+}
+
+func (e *events) Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	e.ctx = ctx
+	e.cancel = cancel
+
+	msgs, errs := e.client.Events(ctx, dockerTypes.EventsOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("type", "container"),
-			filters.Arg("label", fmt.Sprintf("m1k1o.neko_rooms.instance=%s", manager.config.InstanceName)),
+			filters.Arg("label", fmt.Sprintf("m1k1o.neko_rooms.instance=%s", e.config.InstanceName)),
 			filters.Arg("event", "create"),
 			filters.Arg("event", "start"),
-			//filters.Arg("event", "health_status"),
+			filters.Arg("event", "health_status"),
 			filters.Arg("event", "stop"),
 			filters.Arg("event", "destroy"),
 		),
 	})
 
-	manager.eventsWg.Add(1)
+	e.wg.Add(1)
 	go func() {
-		defer manager.eventsWg.Done()
+		defer e.wg.Done()
 
 		for {
 			select {
 			case err, ok := <-errs:
 				if !ok {
-					manager.logger.Fatal().Msg("docker event error channel closed")
+					e.logger.Error().Msg("docker event error channel closed")
 					return
 				}
 
-				manager.logger.Err(err).Msg("got docker event error")
+				e.logger.Err(err).Msg("got docker event error")
 				return
+			case roomId := <-e.roomsReadyCh:
+				e.logger.Info().Str("id", roomId).Msg("room ready")
+
+				// ignore if room was already ready
+				if !e.setRoomReady(roomId) {
+					continue
+				}
+
+				e.broadcast(types.RoomEvent{
+					ID:     roomId,
+					Action: "ready",
+				})
 			case msg, ok := <-msgs:
 				if !ok {
-					manager.logger.Fatal().Msg("docker event message channel closed")
+					e.logger.Error().Msg("docker event message channel closed")
 					return
 				}
 
-				e := types.RoomEvent{
-					ID:     msg.Actor.ID[:12],
-					Action: msg.Action,
-					Labels: msg.Actor.Attributes,
-				}
+				roomId := msg.Actor.ID[:12]
 
-				manager.logger.Info().
-					Str("id", e.ID).
-					Str("action", e.Action).
+				e.logger.Info().
+					Str("id", roomId).
+					Str("action", msg.Action).
 					Msg("got docker event")
 
-				// broadcast event
-				manager.eventsMu.Lock()
-				for _, listener := range manager.eventsListeners {
-					listener <- e
+				action := ""
+				switch msg.Action {
+				case "create":
+					action = "created"
+				case "start":
+					action = "started"
+					e.waitForRoomReady(roomId)
+				case "health_status: healthy":
+					action = "ready"
+					// ignore if room was already ready
+					if !e.setRoomReady(roomId) {
+						continue
+					}
+				case "stop":
+					action = "stopped"
+					e.setRoomNotReady(roomId)
+				case "destroy":
+					action = "destroyed"
 				}
-				manager.eventsMu.Unlock()
+
+				e.broadcast(types.RoomEvent{
+					ID:     roomId,
+					Action: action,
+					Labels: msg.Actor.Attributes,
+				})
 			}
 		}
 	}()
 }
 
-func (manager *RoomManagerCtx) EventsLoopStop() error {
-	manager.eventsLoopCancel()
-	manager.eventsWg.Wait()
+func (e *events) Shutdown() error {
+	e.cancel()
+	close(e.roomsReadyCh)
+	e.wg.Wait()
 	return nil
 }
 
-func (manager *RoomManagerCtx) Events(ctx context.Context) (<-chan types.RoomEvent, <-chan error) {
+//
+// room ready
+//
+
+func (e *events) waitForRoomReady(roomId string) {
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+
+		// check if room is ready
+		exec, err := e.client.ContainerExecCreate(e.ctx, roomId, dockerTypes.ExecConfig{
+			AttachStdout: true,
+			Cmd: []string{
+				"/bin/bash", "-c",
+				"for ((a=1; a<=5; a++)); do (echo > /dev/tcp/localhost/8080) >/dev/null && echo -n OK && exit; sleep 1; done; exit",
+			},
+		})
+		if err != nil {
+			e.logger.Err(err).Msg("failed to create exec")
+			return
+		}
+
+		conn, err := e.client.ContainerExecAttach(e.ctx, exec.ID, dockerTypes.ExecStartCheck{})
+		if err != nil {
+			e.logger.Err(err).Msg("failed to attach exec")
+			return
+		}
+		defer conn.Close()
+
+		data, err := io.ReadAll(conn.Reader)
+		if err != nil {
+			e.logger.Err(err).Msg("failed to read exec")
+			return
+		}
+
+		if strings.HasSuffix(string(data), "OK") {
+			e.logger.Info().Str("id", roomId).Msg("room ready")
+			e.roomsReadyCh <- roomId
+			return
+		}
+
+		e.logger.Info().Str("id", roomId).Str("data", string(data)).Msg("room not ready")
+	}()
+}
+
+func (e *events) setRoomReady(roomId string) bool {
+	e.roomsReadyMu.Lock()
+	defer e.roomsReadyMu.Unlock()
+
+	_, ok := e.roomsReady[roomId]
+	e.roomsReady[roomId] = struct{}{}
+	return !ok
+}
+
+func (e *events) setRoomNotReady(roomId string) {
+	e.roomsReadyMu.Lock()
+	defer e.roomsReadyMu.Unlock()
+
+	delete(e.roomsReady, roomId)
+}
+
+func (e *events) IsRoomReady(roomId string) bool {
+	e.roomsReadyMu.Lock()
+	defer e.roomsReadyMu.Unlock()
+
+	_, ok := e.roomsReady[roomId]
+	return ok
+}
+
+//
+// events
+//
+
+func (e *events) broadcast(event types.RoomEvent) {
+	e.listenersMu.Lock()
+	for _, listener := range e.listeners {
+		listener <- event
+	}
+	e.listenersMu.Unlock()
+}
+
+func (e *events) Events(ctx context.Context) (<-chan types.RoomEvent, <-chan error) {
 	messages := make(chan types.RoomEvent)
 	errs := make(chan error, 1)
 
 	// add listener
-	manager.eventsMu.Lock()
-	manager.eventsListeners = append(manager.eventsListeners, messages)
-	manager.eventsMu.Unlock()
+	e.listenersMu.Lock()
+	e.listeners = append(e.listeners, messages)
+	e.listenersMu.Unlock()
 
-	manager.eventsWg.Add(1)
+	e.wg.Add(1)
 	go func() {
-		defer manager.eventsWg.Done()
+		defer e.wg.Done()
 		defer close(errs)
 
 		select {
 		case <-ctx.Done():
 			errs <- ctx.Err()
-		case <-manager.eventsLoopCtx.Done():
-			errs <- fmt.Errorf("room manager shutdown")
+		case <-e.ctx.Done():
+			errs <- fmt.Errorf("room events shutdown")
 			return
 		}
 
 		// remove listener
-		manager.eventsMu.Lock()
-		for i, listener := range manager.eventsListeners {
+		e.listenersMu.Lock()
+		for i, listener := range e.listeners {
 			if listener == messages {
-				manager.eventsListeners = append(manager.eventsListeners[:i], manager.eventsListeners[i+1:]...)
+				e.listeners = append(e.listeners[:i], e.listeners[i+1:]...)
 				break
 			}
 		}
-		manager.eventsMu.Unlock()
+		e.listenersMu.Unlock()
 	}()
 
 	return messages, errs

--- a/internal/room/events.go
+++ b/internal/room/events.go
@@ -93,8 +93,9 @@ func (e *events) Start() {
 
 				e.broadcast(types.RoomEvent{
 					ID:     room.id,
-					Action: "ready",
-					Labels: room.labels,
+					Action: types.RoomEventReady,
+
+					ContainerLabels: room.labels,
 				})
 			case msg := <-msgs:
 				roomId := msg.Actor.ID[:12]
@@ -105,30 +106,31 @@ func (e *events) Start() {
 					Str("action", msg.Action).
 					Msg("got docker event")
 
-				action := ""
+				var action types.RoomEventAction
 				switch msg.Action {
 				case "create":
-					action = "created"
+					action = types.RoomEventCreated
 				case "start":
-					action = "started"
+					action = types.RoomEventStarted
 					e.waitForRoomReady(roomId, labels)
 				case "health_status: healthy":
-					action = "ready"
+					action = types.RoomEventReady
 					// ignore if room was already ready
 					if !e.setRoomReady(roomId) {
 						continue
 					}
 				case "stop":
-					action = "stopped"
+					action = types.RoomEventStopped
 					e.setRoomNotReady(roomId)
 				case "destroy":
-					action = "destroyed"
+					action = types.RoomEventDestroyed
 				}
 
 				e.broadcast(types.RoomEvent{
 					ID:     roomId,
 					Action: action,
-					Labels: labels,
+
+					ContainerLabels: labels,
 				})
 			}
 		}

--- a/internal/room/events.go
+++ b/internal/room/events.go
@@ -1,0 +1,112 @@
+package room
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/m1k1o/neko-rooms/internal/types"
+
+	dockerTypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+)
+
+func (manager *RoomManagerCtx) EventsLoopStart() {
+	ctx, cancel := context.WithCancel(context.Background())
+	manager.eventsLoopCtx = ctx
+	manager.eventsLoopCancel = cancel
+
+	msgs, errs := manager.client.Events(ctx, dockerTypes.EventsOptions{
+		Filters: filters.NewArgs(
+			filters.Arg("type", "container"),
+			filters.Arg("label", fmt.Sprintf("m1k1o.neko_rooms.instance=%s", manager.config.InstanceName)),
+			filters.Arg("event", "create"),
+			filters.Arg("event", "start"),
+			//filters.Arg("event", "health_status"),
+			filters.Arg("event", "stop"),
+			filters.Arg("event", "destroy"),
+		),
+	})
+
+	manager.eventsWg.Add(1)
+	go func() {
+		defer manager.eventsWg.Done()
+
+		for {
+			select {
+			case err, ok := <-errs:
+				if !ok {
+					manager.logger.Fatal().Msg("docker event error channel closed")
+					return
+				}
+
+				manager.logger.Err(err).Msg("got docker event error")
+				return
+			case msg, ok := <-msgs:
+				if !ok {
+					manager.logger.Fatal().Msg("docker event message channel closed")
+					return
+				}
+
+				e := types.RoomEvent{
+					ID:     msg.Actor.ID[:12],
+					Action: msg.Action,
+					Labels: msg.Actor.Attributes,
+				}
+
+				manager.logger.Info().
+					Str("id", e.ID).
+					Str("action", e.Action).
+					Msg("got docker event")
+
+				// broadcast event
+				manager.eventsMu.Lock()
+				for _, listener := range manager.eventsListeners {
+					listener <- e
+				}
+				manager.eventsMu.Unlock()
+			}
+		}
+	}()
+}
+
+func (manager *RoomManagerCtx) EventsLoopStop() error {
+	manager.eventsLoopCancel()
+	manager.eventsWg.Wait()
+	return nil
+}
+
+func (manager *RoomManagerCtx) Events(ctx context.Context) (<-chan types.RoomEvent, <-chan error) {
+	messages := make(chan types.RoomEvent)
+	errs := make(chan error, 1)
+
+	// add listener
+	manager.eventsMu.Lock()
+	manager.eventsListeners = append(manager.eventsListeners, messages)
+	manager.eventsMu.Unlock()
+
+	manager.eventsWg.Add(1)
+	go func() {
+		defer manager.eventsWg.Done()
+		defer close(errs)
+
+		select {
+		case <-ctx.Done():
+			errs <- ctx.Err()
+		case <-manager.eventsLoopCtx.Done():
+			errs <- fmt.Errorf("room manager shutdown")
+			return
+		}
+
+		// remove listener
+		manager.eventsMu.Lock()
+		for i, listener := range manager.eventsListeners {
+			if listener == messages {
+				manager.eventsListeners = append(manager.eventsListeners[:i], manager.eventsListeners[i+1:]...)
+				break
+			}
+		}
+		manager.eventsMu.Unlock()
+	}()
+
+	return messages, errs
+}

--- a/internal/room/events.go
+++ b/internal/room/events.go
@@ -99,7 +99,7 @@ func (e *events) Start() {
 				roomId := msg.Actor.ID[:12]
 				labels := msg.Actor.Attributes
 
-				e.logger.Info().
+				e.logger.Debug().
 					Str("id", roomId).
 					Str("action", msg.Action).
 					Msg("got docker event")
@@ -178,7 +178,7 @@ func (e *events) waitForRoomReady(roomId string, labels map[string]string) {
 		}
 
 		if strings.HasSuffix(string(data), "OK") {
-			e.logger.Info().Str("id", roomId).Msg("room ready")
+			e.logger.Debug().Str("id", roomId).Msg("room ready")
 			e.roomsReadyCh <- roomReady{
 				id:     roomId,
 				labels: labels,
@@ -186,7 +186,7 @@ func (e *events) waitForRoomReady(roomId string, labels map[string]string) {
 			return
 		}
 
-		e.logger.Info().Str("id", roomId).Str("data", string(data)).Msg("room not ready")
+		e.logger.Warn().Str("id", roomId).Str("data", string(data)).Msg("room not ready")
 	}()
 }
 

--- a/internal/room/manager.go
+++ b/internal/room/manager.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/docker/cli/opts"
@@ -55,6 +56,12 @@ type RoomManagerCtx struct {
 	logger zerolog.Logger
 	config *config.Room
 	client *dockerClient.Client
+
+	eventsMu         sync.Mutex
+	eventsWg         sync.WaitGroup
+	eventsListeners  []chan types.RoomEvent
+	eventsLoopCtx    context.Context
+	eventsLoopCancel context.CancelFunc
 }
 
 func (manager *RoomManagerCtx) Config() types.RoomsConfig {

--- a/internal/room/manager.go
+++ b/internal/room/manager.go
@@ -724,7 +724,10 @@ func (manager *RoomManagerCtx) Remove(ctx context.Context, id string) error {
 	}
 
 	// Stop the actual container
-	err = manager.client.ContainerStop(ctx, id, container.StopOptions{})
+	err = manager.client.ContainerStop(ctx, id, container.StopOptions{
+		Signal:  "SIGTERM",
+		Timeout: &manager.config.StopTimeoutSec,
+	})
 
 	if err != nil {
 		return err
@@ -998,7 +1001,10 @@ func (manager *RoomManagerCtx) Stop(ctx context.Context, id string) error {
 	}
 
 	// Stop the actual container
-	return manager.client.ContainerStop(ctx, id, container.StopOptions{})
+	return manager.client.ContainerStop(ctx, id, container.StopOptions{
+		Signal:  "SIGTERM",
+		Timeout: &manager.config.StopTimeoutSec,
+	})
 }
 
 func (manager *RoomManagerCtx) Restart(ctx context.Context, id string) error {
@@ -1008,7 +1014,10 @@ func (manager *RoomManagerCtx) Restart(ctx context.Context, id string) error {
 	}
 
 	// Restart the actual container
-	return manager.client.ContainerRestart(ctx, id, container.StopOptions{})
+	return manager.client.ContainerRestart(ctx, id, container.StopOptions{
+		Signal:  "SIGTERM",
+		Timeout: &manager.config.StopTimeoutSec,
+	})
 }
 
 // events

--- a/internal/types/room.go
+++ b/internal/types/room.go
@@ -27,6 +27,8 @@ type RoomEntry struct {
 	Status         string            `json:"status"`
 	Created        time.Time         `json:"created"`
 	Labels         map[string]string `json:"labels,omitempty"`
+
+	ContainerLabels map[string]string `json:"-"` // for internal use
 }
 
 type MountType string
@@ -139,10 +141,21 @@ type RoomMember struct {
 	Muted bool   `json:"muted"`
 }
 
+type RoomEventAction string
+
+const (
+	RoomEventCreated   RoomEventAction = "created"
+	RoomEventStarted   RoomEventAction = "started"
+	RoomEventReady     RoomEventAction = "ready"
+	RoomEventStopped   RoomEventAction = "stopped"
+	RoomEventDestroyed RoomEventAction = "destroyed"
+)
+
 type RoomEvent struct {
-	ID     string            `json:"id"`
-	Action string            `json:"action"`
-	Labels map[string]string `json:"-"`
+	ID     string          `json:"id"`
+	Action RoomEventAction `json:"action"`
+
+	ContainerLabels map[string]string `json:"-"` // for internal use
 }
 
 var ErrRoomNotFound = fmt.Errorf("room not found")

--- a/internal/types/room.go
+++ b/internal/types/room.go
@@ -138,6 +138,12 @@ type RoomMember struct {
 	Muted bool   `json:"muted"`
 }
 
+type RoomEvent struct {
+	ID     string            `json:"id"`
+	Action string            `json:"action"`
+	Labels map[string]string `json:"-"`
+}
+
 var ErrRoomNotFound = fmt.Errorf("room not found")
 
 type RoomManager interface {
@@ -155,4 +161,8 @@ type RoomManager interface {
 	Start(ctx context.Context, id string) error
 	Stop(ctx context.Context, id string) error
 	Restart(ctx context.Context, id string) error
+
+	EventsLoopStart()
+	EventsLoopStop() error
+	Events(ctx context.Context) (<-chan RoomEvent, <-chan error)
 }

--- a/internal/types/room.go
+++ b/internal/types/room.go
@@ -23,6 +23,7 @@ type RoomEntry struct {
 	IsOutdated     bool              `json:"is_outdated"`
 	MaxConnections uint16            `json:"max_connections"` // 0 when using mux
 	Running        bool              `json:"running"`
+	IsReady        bool              `json:"is_ready"`
 	Status         string            `json:"status"`
 	Created        time.Time         `json:"created"`
 	Labels         map[string]string `json:"labels,omitempty"`

--- a/neko.go
+++ b/neko.go
@@ -144,8 +144,7 @@ func (main *MainCtx) Start() {
 	)
 
 	main.proxyManager = proxy.New(
-		client,
-		main.Configs.Room.InstanceName,
+		main.roomManager,
 		main.Configs.Room.WaitEnabled,
 	)
 	main.proxyManager.Start()

--- a/neko.go
+++ b/neko.go
@@ -131,6 +131,7 @@ func (main *MainCtx) Start() {
 		client,
 		main.Configs.Room,
 	)
+	main.roomManager.EventsLoopStart()
 
 	main.pullManager = pull.New(
 		client,
@@ -169,6 +170,9 @@ func (main *MainCtx) Shutdown() {
 
 	err = main.pullManager.Shutdown()
 	main.logger.Err(err).Msg("pull manager shutdown")
+
+	err = main.roomManager.EventsLoopStop()
+	main.logger.Err(err).Msg("room events loop shutdown")
 }
 
 func (main *MainCtx) ServeCommand(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
- Allow API users to subscribe to room events in real time.
- Add `IS_READY` field to the room entry, so that API users know when the room is ready.
- Add `StopTimeoutSec` to config, that specifies how long can a room gracefully shutdown.
- Refactor proxy to use new room events, not the docker events directly.