### PR TITLE
NGINX WebSocket and Proxy Improvements

### DIFF
--- a/community/scripts/ubuntu-debian.sh
+++ b/community/scripts/ubuntu-debian.sh
@@ -589,9 +589,13 @@ server {
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto \$scheme;
 
-        proxy_cache_bypass \$http_upgrade;
-        proxy_buffering off;
-        proxy_read_timeout 900s;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout    4h;
+        proxy_read_timeout    4h;
+        send_timeout          900s;
+
+        proxy_request_buffering off;
+        proxy_buffering        off;
     }
 
     # Admin Panel Restricted Access

--- a/community/scripts/ubuntu-debian.sh
+++ b/community/scripts/ubuntu-debian.sh
@@ -604,7 +604,7 @@ server {
     }
 
     # Admin Panel Restricted Access
-    location ~ ^/$ {
+    location = / {
         auth_basic "Restricted Access";
         auth_basic_user_file /etc/nginx/.htpasswd;
 

--- a/community/scripts/ubuntu-debian.sh
+++ b/community/scripts/ubuntu-debian.sh
@@ -607,7 +607,19 @@ server {
     location ~ ^/$ {
         auth_basic "Restricted Access";
         auth_basic_user_file /etc/nginx/.htpasswd;
+
         proxy_pass http://127.0.0.1:${DOCKER_PORT};
+        proxy_set_header Host $host;
+        proxy_http_version 1.1;
+
+        # Falls das Admin-UI WebSockets nutzt, sind wir vorbereitet
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        # Forwarding headers wie oben
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
 EOF

--- a/community/scripts/ubuntu-debian.sh
+++ b/community/scripts/ubuntu-debian.sh
@@ -580,14 +580,14 @@ server {
     listen 80;
     server_name ${DOMAIN};
 
-    location / {
+    location ^~ /${PATH_PREFIX}/ {
         proxy_pass http://127.0.0.1:${DOCKER_PORT};
         proxy_set_header Host \$host;
         proxy_http_version 1.1;
 
         # WebSocket headers
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection \$connection_upgrade;
 
         # Forwarding headers for reverse proxy
         proxy_set_header X-Real-IP \$remote_addr;
@@ -604,22 +604,22 @@ server {
     }
 
     # Admin Panel Restricted Access
-    location = / {
+    location / {
         auth_basic "Restricted Access";
         auth_basic_user_file /etc/nginx/.htpasswd;
 
         proxy_pass http://127.0.0.1:${DOCKER_PORT};
-        proxy_set_header Host $host;
+        proxy_set_header Host \$host;
         proxy_http_version 1.1;
 
         # Falls das Admin-UI WebSockets nutzt, sind wir vorbereitet
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection \$connection_upgrade;
 
         # Forwarding headers wie oben
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
     }
 }
 EOF

--- a/community/scripts/ubuntu-debian.sh
+++ b/community/scripts/ubuntu-debian.sh
@@ -571,6 +571,11 @@ echo -e "${AQUA}\n==================================================${NC}"
 # Configure NGINX without SSL
 echo -e "${YELLOW}Configuring NGINX without SSL...${NC}"
 cat <<EOF > /etc/nginx/sites-available/${DOMAIN}-neko-rooms.conf
+map \$http_upgrade \$connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 80;
     server_name ${DOMAIN};
@@ -581,8 +586,8 @@ server {
         proxy_http_version 1.1;
 
         # WebSocket headers
-        proxy_set_header Upgrade \$http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
 
         # Forwarding headers for reverse proxy
         proxy_set_header X-Real-IP \$remote_addr;


### PR DESCRIPTION
This pull request updates the NGINX configuration in the `community/scripts/ubuntu-debian.sh` script to improve WebSocket support, connection handling, and reverse proxy reliability for the application. The changes focus on better handling of upgrade headers, timeouts, and buffering, as well as reorganizing location blocks for more secure and robust proxying.

**NGINX WebSocket and Proxy Improvements:**

* Added a `map` directive to dynamically set the `Connection` header for WebSocket upgrades, replacing the static "upgrade" value with a context-aware variable (`$connection_upgrade`).
* Enhanced the main proxy location (`location ^~ /${PATH_PREFIX}/`) by adding custom timeout values (`proxy_connect_timeout`, `proxy_send_timeout`, `proxy_read_timeout`, `send_timeout`) and disabling request buffering for better real-time communication.
* Replaced the generic root location with a restricted admin location (`location /`) that now also supports WebSocket headers and forwards all necessary proxy headers, ensuring consistency and security for admin access.